### PR TITLE
design: 비밀번호 찾기 UI 제작

### DIFF
--- a/koinOwner.xcodeproj/project.pbxproj
+++ b/koinOwner.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		1B5D7E802C34E0C000850B30 /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5D7E7F2C34E0C000850B30 /* CustomNavigationBar.swift */; };
 		D229EBC42C33A7C7004D54F9 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = D229EBC32C33A7C7004D54F9 /* .swiftlint.yml */; };
 		D23944772C3BBE9800048F45 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944762C3BBE9800048F45 /* RegisterView.swift */; };
+		D239449A2C3CC63800048F45 /* FindPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944992C3CC63800048F45 /* FindPasswordView.swift */; };
 		D28E2F152C369CC2004A64D5 /* RegistrationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */; };
 		D28E2F172C36C8BE004A64D5 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */; };
 		D28E2F192C381BE6004A64D5 /* BusinessVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */; };
@@ -50,6 +51,7 @@
 		1B5D7E7F2C34E0C000850B30 /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		D229EBC32C33A7C7004D54F9 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D23944762C3BBE9800048F45 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
+		D23944992C3CC63800048F45 /* FindPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPasswordView.swift; sourceTree = "<group>"; };
 		D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFormView.swift; sourceTree = "<group>"; };
 		D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessVerificationView.swift; sourceTree = "<group>"; };
@@ -144,6 +146,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		D23944922C3CC56300048F45 /* FindPassword */ = {
+			isa = PBXGroup;
+			children = (
+				D23944992C3CC63800048F45 /* FindPasswordView.swift */,
+			);
+			path = FindPassword;
+			sourceTree = "<group>";
+		};
 		D2E5F2212C363C58000B92CB /* Register */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,6 +232,7 @@
 		D2EE258A2C325902000B8015 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				D23944922C3CC56300048F45 /* FindPassword */,
 				D2E5F2212C363C58000B92CB /* Register */,
 				1B5D7E7B2C34DED600850B30 /* Main */,
 			);
@@ -335,6 +346,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D239449A2C3CC63800048F45 /* FindPasswordView.swift in Sources */,
 				1B303B692C365F9F00E1ECEA /* MainView+MenuTab.swift in Sources */,
 				1B5D7E802C34E0C000850B30 /* CustomNavigationBar.swift in Sources */,
 				D2EE257D2C30A460000B8015 /* ContentView.swift in Sources */,

--- a/koinOwner.xcodeproj/project.pbxproj
+++ b/koinOwner.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D229EBC42C33A7C7004D54F9 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = D229EBC32C33A7C7004D54F9 /* .swiftlint.yml */; };
 		D23944772C3BBE9800048F45 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944762C3BBE9800048F45 /* RegisterView.swift */; };
 		D239449A2C3CC63800048F45 /* FindPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944992C3CC63800048F45 /* FindPasswordView.swift */; };
+		D239449C2C3CC6D400048F45 /* AccountVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */; };
 		D28E2F152C369CC2004A64D5 /* RegistrationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */; };
 		D28E2F172C36C8BE004A64D5 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */; };
 		D28E2F192C381BE6004A64D5 /* BusinessVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */; };
@@ -52,6 +53,7 @@
 		D229EBC32C33A7C7004D54F9 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		D23944762C3BBE9800048F45 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		D23944992C3CC63800048F45 /* FindPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPasswordView.swift; sourceTree = "<group>"; };
+		D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationView.swift; sourceTree = "<group>"; };
 		D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFormView.swift; sourceTree = "<group>"; };
 		D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessVerificationView.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				D23944992C3CC63800048F45 /* FindPasswordView.swift */,
+				D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */,
 			);
 			path = FindPassword;
 			sourceTree = "<group>";
@@ -364,6 +367,7 @@
 				1B5D7E7D2C34DF3000850B30 /* MainView.swift in Sources */,
 				1B5D7E542C32A25A00850B30 /* Font+Custom.swift in Sources */,
 				1B303B6B2C3667DC00E1ECEA /* MainView+EventTab.swift in Sources */,
+				D239449C2C3CC6D400048F45 /* AccountVerificationView.swift in Sources */,
 				D2EE257B2C30A460000B8015 /* koinOwnerApp.swift in Sources */,
 				D28E2F192C381BE6004A64D5 /* BusinessVerificationView.swift in Sources */,
 			);

--- a/koinOwner.xcodeproj/project.pbxproj
+++ b/koinOwner.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D23944772C3BBE9800048F45 /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944762C3BBE9800048F45 /* RegisterView.swift */; };
 		D239449A2C3CC63800048F45 /* FindPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23944992C3CC63800048F45 /* FindPasswordView.swift */; };
 		D239449C2C3CC6D400048F45 /* AccountVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */; };
+		D239449E2C3CC8E200048F45 /* ChangePasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D239449D2C3CC8E200048F45 /* ChangePasswordView.swift */; };
 		D28E2F152C369CC2004A64D5 /* RegistrationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */; };
 		D28E2F172C36C8BE004A64D5 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */; };
 		D28E2F192C381BE6004A64D5 /* BusinessVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */; };
@@ -54,6 +55,7 @@
 		D23944762C3BBE9800048F45 /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		D23944992C3CC63800048F45 /* FindPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPasswordView.swift; sourceTree = "<group>"; };
 		D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountVerificationView.swift; sourceTree = "<group>"; };
+		D239449D2C3CC8E200048F45 /* ChangePasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePasswordView.swift; sourceTree = "<group>"; };
 		D28E2F142C369CC2004A64D5 /* RegistrationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFormView.swift; sourceTree = "<group>"; };
 		D28E2F162C36C8BE004A64D5 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		D28E2F182C381BE6004A64D5 /* BusinessVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusinessVerificationView.swift; sourceTree = "<group>"; };
@@ -153,6 +155,7 @@
 			children = (
 				D23944992C3CC63800048F45 /* FindPasswordView.swift */,
 				D239449B2C3CC6D400048F45 /* AccountVerificationView.swift */,
+				D239449D2C3CC8E200048F45 /* ChangePasswordView.swift */,
 			);
 			path = FindPassword;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D239449A2C3CC63800048F45 /* FindPasswordView.swift in Sources */,
+				D239449E2C3CC8E200048F45 /* ChangePasswordView.swift in Sources */,
 				1B303B692C365F9F00E1ECEA /* MainView+MenuTab.swift in Sources */,
 				1B5D7E802C34E0C000850B30 /* CustomNavigationBar.swift in Sources */,
 				D2EE257D2C30A460000B8015 /* ContentView.swift in Sources */,

--- a/koinOwner/Sources/Modules/FindPassword/AccountVerificationView.swift
+++ b/koinOwner/Sources/Modules/FindPassword/AccountVerificationView.swift
@@ -1,0 +1,45 @@
+//
+//  AccountVerificationView.swift
+//  koinOwner
+//
+//  Created by 김나훈 on 7/9/24.
+//
+
+import SwiftUI
+
+struct AccountVerificationView: View {
+    @State private var phoneNumber: String = ""
+    @State private var verificationCode: String = ""
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+                Text("휴대폰 번호").padding(.top, 25).padding(.leading, 8)
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(Color(.neutral800))
+                    CustomTextField(placeholder: "- 없이 번호를 입력해주세요.", text: $phoneNumber)
+                        .padding(.top, 7)
+                Text("인증번호").padding(.top, 25).padding(.leading, 8)
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(Color(.neutral800))
+            HStack {
+                CustomTextField(placeholder: "인증번호를 입력해주세요.", text: $verificationCode)
+                    .padding(.top, 7)
+                Button(action: {
+                    
+                }) {
+                    Text("인증번호 발송")
+                        .frame(width: 106, height: 41)
+                        .font(.pretendard(.medium, size: 15))
+                        .foregroundStyle(Color.neutral0)
+                        .background(Color.main500)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+            Spacer()
+        }
+    
+    }
+}
+
+#Preview {
+    AccountVerificationView()
+}

--- a/koinOwner/Sources/Modules/FindPassword/ChangePasswordView.swift
+++ b/koinOwner/Sources/Modules/FindPassword/ChangePasswordView.swift
@@ -1,0 +1,34 @@
+//
+//  ChangePasswordView.swift
+//  koinOwner
+//
+//  Created by 김나훈 on 7/9/24.
+//
+
+import SwiftUI
+
+struct ChangePasswordView: View {
+    @State private var password: String = ""
+    @State private var confirmPassword: String = ""
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+                Text("새 비밀번호").padding(.top, 25).padding(.leading, 8)
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(Color(.neutral800))
+                    CustomTextField(placeholder: "새 비밀번호를 입력해주세요..", text: $password)
+                        .padding(.top, 7)
+                Text("비밀번호 확인").padding(.top, 25).padding(.leading, 8)
+                    .font(.pretendard(.medium, size: 14))
+                    .foregroundStyle(Color(.neutral800))
+   
+                CustomTextField(placeholder: "새 비밀번호를 다시 입력해주세요.", text: $confirmPassword)
+                    .padding(.top, 7)
+          
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    ChangePasswordView()
+}

--- a/koinOwner/Sources/Modules/FindPassword/FindPasswordView.swift
+++ b/koinOwner/Sources/Modules/FindPassword/FindPasswordView.swift
@@ -29,7 +29,12 @@ struct FindPasswordView: View {
                 }
                 CustomProgressBar(progress: Double(currentStep) / 2.0)
                     .frame(height: 8).padding(.top, 8)
-
+                switch currentStep {
+                case 1:
+                    AccountVerificationView()
+                default:
+                    ChangePasswordView()
+                }
                 Spacer()
                 Button(action: {
                     currentStep += 1

--- a/koinOwner/Sources/Modules/FindPassword/FindPasswordView.swift
+++ b/koinOwner/Sources/Modules/FindPassword/FindPasswordView.swift
@@ -1,0 +1,54 @@
+//
+//  FindPasswordView.swift
+//  koinOwner
+//
+//  Created by 김나훈 on 7/9/24.
+//
+
+import SwiftUI
+
+struct FindPasswordView: View {
+    @State private var currentStep: Int = 1
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Group {
+                        switch currentStep {
+                        case 1: Text("1. 계정 인증")
+                        default: Text("2. 비밀번호 변경")
+                        }
+                    }
+                    .font(.pretendard(.medium, size: 16))
+                    .foregroundStyle(Color.main500)
+                    
+                    Spacer()
+                    Text("\(currentStep) / 2")
+                        .font(.pretendard(.medium, size: 16))
+                        .foregroundStyle(Color.main500)
+                }
+                CustomProgressBar(progress: Double(currentStep) / 2.0)
+                    .frame(height: 8).padding(.top, 8)
+
+                Spacer()
+                Button(action: {
+                    currentStep += 1
+                }) {
+                    Text("다음")
+                        .font(.pretendard(.medium, size: 15))
+                        .foregroundStyle(Color.neutral600)
+                        .frame(maxWidth: .infinity, minHeight: 48)
+                        .background(Color.neutral300)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+                .padding(.bottom, 10)
+            }.padding(.top, 16).padding(.horizontal, 16)
+                .navigationTitle("비밀번호 찾기")
+                .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+    
+}
+#Preview {
+    FindPasswordView()
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #9 

## 📝작업 내용

> 비밀번호를 찾는 화면 디자인 헀습니다.

### 스크린샷 (선택)

<img width="292" alt="Capture 1" src="https://github.com/BCSDLab/KOIN_OWNER_iOS/assets/118811606/a4784c2d-c93d-4351-82c7-ed76ee7ead83">
<img width="262" alt="Capture 2" src="https://github.com/BCSDLab/KOIN_OWNER_iOS/assets/118811606/fa897468-5a23-4296-820d-f3c39f408824">


## 💬리뷰 요구사항(선택)

TextField 밑에 원래 라벨이 있어야 하는데 
<img width="280" alt="Capture" src="https://github.com/BCSDLab/KOIN_OWNER_iOS/assets/118811606/28042787-454a-47b9-9637-a9c245d4f03f">
나중에 회원가입 화면과 같이 재사용 가능하게 (상태에 따라 Warning, Common 으로 색상구분 ) 나누겠습니다.


